### PR TITLE
Updated the git clone URL to point to CobraLab instead of pipitone.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To [cite MAGeTbrain in publications](CITATION), please use:
 
 ## For the impatient:
 
-    git clone https://github.com/pipitone/MAGeTbrain
+    git clone https://github.com/CobraLab/MAGeTbrain.git
     source MAGeTbrain/bin/activate
     mb init segmentations
     cd segmentations
@@ -36,7 +36,7 @@ To [cite MAGeTbrain in publications](CITATION), please use:
 
 0. Check out a copy of this repository somewhere handy,
     
-        git clone git://github.com/pipitone/MAGeTbrain.git 
+        git clone https://github.com/CobraLab/MAGeTbrain.git
 
 1. Add the `MAGeTbrain/bin` folder to your path. This can be done easily by
 running, `source MAGeTbrain/bin/activate` (revert PATH by typing `deactivate`). 


### PR DESCRIPTION
In the ReadME.md file, the URL to clone the repository pointed to @pipitone 's repo instead of the official CobraLab one. If that was intented, please discard this PR. Else, this fixes it.