### PR TITLE
Fix for using 'parallel' queue.

### DIFF
--- a/bin/mb
+++ b/bin/mb
@@ -257,28 +257,33 @@ def command_run(options):
   
   if options.stage == "register": 
     p.stage_register_atlases() 
-  if options.stage == "vote" or (options.stage == 'vanilla' and options.queue == 'parallel'): 
+  elif options.stage == "vote": # or (options.stage == 'vanilla' and options.queue == 'parallel'): 
     #TODO assumes all atlases have been registered, but we should check here
     #that that's so.
     p.stage_vote()
-   
-
-  if options.stage == "vanilla" and options.queue == 'qbatch':
+  elif options.stage == "vanilla": 
     p.stage_register_atlases() 
-    for subject in subjects:
-      _, label = p.fused_label_path(subject) 
-      if exists(label):
-        continue
-      # HACK the command line to run the voting stage next
-      commandline = ' '.join(sys.argv)
-      commandline = commandline.replace('vanilla', '')
-      commandline = commandline.replace('run', 'run vote -s ' + subject.stem)
-      if ' -q ' in commandline:
-        commandline = commandline.replace('-q qbatch', '-q parallel')
-      else:
-        commandline = commandline + ' -q parallel'
-  
-      p.queue.append_commands(STAGE_VOTE, [commandline])
+
+    if options.queue == 'qbatch':  # submit each subject's voting as a separate job
+      for subject in subjects:
+	_, label = p.fused_label_path(subject) 
+	if exists(label):
+	  continue
+	# HACK the command line to run the voting stage next
+	commandline = ' '.join(sys.argv)
+	commandline = commandline.replace('vanilla', '')
+	commandline = commandline.replace('run', 'run vote -s ' + subject.stem)
+	if ' -q ' in commandline:
+	  commandline = commandline.replace('-q qbatch', '-q parallel')
+	else:
+	  commandline = commandline + ' -q parallel'
+    
+	p.queue.append_commands(STAGE_VOTE, [commandline])
+    else:  # we aren't in batch mode, so do all of the voting and whatnot directly
+	warning("'vanilla' mode only works for the 'qbatch' queue.")
+        warning("Other queues treat this as stage as 'register'. " + 
+                "You will need to run the 'voting' stage separately.") 
+        
 
   p.run()
  
@@ -562,7 +567,7 @@ class MAGeTBrain(object):
     assert len(stems) > 1
     xfms = []
     for s, t in zip(stems[:-1],stems[1:]):
-      _, xfm = self.xfm_path(s, t, xfmbasedir, check_reg_dir = True)
+      _, xfm = self.xfm_path(s, t, basedir=xfmbasedir, check_reg_dir = True)
       xfms.append(xfm)
     joined_xfm   = join(self.temp_dir,'.'.join(stems) + ".xfm")
     if not exists(joined_xfm): 
@@ -578,7 +583,7 @@ class MAGeTBrain(object):
     return (output_dir, lbl)
 
   def xfm_path(self, source, target, basedir = None, check_reg_dir = False):
-    """Returns the XFM path for registration of between to images
+    """Returns the XFM path for registration between two images
 
        Expects that source and target are Template instances, and provides the
        output directory and transform path rooted at basedir. basedir defaults 


### PR DESCRIPTION
This commit is a partial fixup of the logic around queueing up stages when using the 'parallel' queue.

The problem is this: if atlases-template registrations aren't already done, then during construction of the voting stage commands, xfmjoin mistakenly uses a path to the temporary folder for atlas-template xfms.  It should look at the output/registrations folder, but since the registrations haven't been completed at the time of construction, it defaults to the temp folder. This is never a problem when using the vanilla mode (atlas-template registration + voting) with the qbatch queue because the construction of voting commands happens in a job that is run only after the atlas-template commands have run.  When using the 'parallel' queue all of the stages are constructed in a single pass and so this is why the XFMs aren't found.

So, with this commit, I've reworked things so that in order to run using the 'parallel' queue, one needs run the 'register' stage, and the 'voting' stage separately. e.g.

   mb run -q parallel register
   mb run -q parallel voting

That is, the 'vanilla' mode does not work for the parallel queue (a warning is displayed and it is treated as only the 'register' stage).

This is obviously a bit of a workaround until we can do something more sensible with handling temporary folders and pipeline construction.