### PR TITLE
MAGeTbrain guideline link correction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Starts the MAGeT brain pipeline.
 
 ## Tutorials
 
-For an in-depth guideline, follow the [MAGeTbrain](https://github.com/CobraLab/documentation/wiki/MAGeT-Brain) and the [MAGeTmorph](https://github.com/CobraLab/documentation/wiki/MAGeT-Morph) tutorials. 
+For an in-depth guideline, follow the [MAGeTbrain](https://github.com/CobraLab/documentation/wiki/MAGeTBrain) and the [MAGeTmorph](https://github.com/CobraLab/documentation/wiki/MAGeT-Morph) tutorials.
 
 ---
     http://tinysong.com/y9lO


### PR DESCRIPTION
The link to the guideline of MAGeTbrain is dead. This is the correction.

Also, the tinysong link is dead but I did not feel like taking it off.